### PR TITLE
✨Feat: 로그인 및 로그아웃 버튼 기능 구현

### DIFF
--- a/src/api/login-user-apis.ts
+++ b/src/api/login-user-apis.ts
@@ -1,0 +1,17 @@
+import axios from 'axios'
+
+export async function checkUser(apiPath: string, token: string | undefined) {
+  const result = await axios
+    .post(
+      `${process.env.NEXT_PUBLIC_API_URL}${apiPath}`,
+      {},
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    )
+    .then((res) => res.data)
+    .catch((error) => console.log(error))
+  return result
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,8 +25,8 @@ export default function RootLayout({
         /> */}
       </head>
       <body suppressHydrationWarning className={inter.className}>
-        <Header />
         <ReduxProvider>
+          <Header />
           <div className="flex bg-green-50 pt-[72px] min-h-screen">
             <div className="grow shrink w-full max-w-[1440px] mx-auto my-0">
               {children}

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,6 +1,69 @@
+'use client'
+import { checkUser } from '@/api/login-user-apis'
+import { getLocalStorage, removeLocalStorage } from '@/lib/local-storage'
+import { LoginInfo, getLoginInfo } from '@/store/user-info-slice'
+
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useEffect, useState } from 'react'
+import { useDispatch } from 'react-redux'
+import { useSelector } from 'react-redux'
 
 export function Header() {
+  const [session, setSession] = useState<boolean>(false)
+  const [userInfo, setUserInfo] = useState<LoginInfo | null>(null)
+
+  const route = useRouter()
+  const state = useSelector((state: any) => state.userInfo)
+  const dispatch = useDispatch()
+
+  // 로그인 성공일 때 받는 redux로 session을 변경(boolean), redux 저장
+  useEffect(() => {
+    setUserInfo(state)
+    checkSession(state)
+  }, [state])
+
+  // localstorage에 token이 남아있다면 session을 변경(boolean), fetch데이터 저장
+  useEffect(() => {
+    const token = getLocalStorage('accessToken')
+    async function handler() {
+      const result = await checkUser('/api/userinfo', token)
+      setUserInfo(result.data)
+      checkSession(result.data)
+    }
+    if (token) {
+      handler()
+    }
+  }, [])
+
+  // fetch 또는 redux로 받아온 데이터(object)의 value가 null인지를 판단해 session을 변경(boolean)
+  function checkSession(info: any) {
+    for (let i in info) {
+      if (info[i] !== null) {
+        setSession(true)
+        return
+      }
+      if (info[i] === null) {
+        setSession(false)
+        return
+      }
+    }
+  }
+
+  function logOutBtn() {
+    const nullState = {
+      id: null,
+      loginId: null,
+      loginType: null,
+      nickName: null,
+      roles: null,
+    }
+    setUserInfo(null)
+    setSession(false)
+    removeLocalStorage('accessToken')
+    dispatch(getLoginInfo(nullState))
+    route.push('/')
+  }
   return (
     <header className="w-full fixed text-gray-600 body-font z-50 ">
       <div className="max-w-[1440px] mx-auto my-0 flex flex-wrap px-3 py-[20px] items-center justify-between bg-[#214D33]">
@@ -10,9 +73,29 @@ export function Header() {
         >
           Recipe Radar
         </Link>
-        <button className="inline-flex items-center bg-gray-100 border-0 py-1 px-3 focus:outline-none hover:bg-gray-200 rounded text-base ">
-          <Link href="/user/login">로그인/회원가입</Link>
-        </button>
+        {session && userInfo ? (
+          <div className="min-w-[150px] flex items-center justify-between">
+            <p className="text-gray-300">
+              <Link href="/my-page" className="w-full">
+                {userInfo.nickName}님
+              </Link>
+            </p>
+            <button
+              type="button"
+              onClick={() => logOutBtn()}
+              className="inline-flex items-center bg-gray-100 border-0 py-1 px-3 focus:outline-none hover:bg-gray-200 rounded text-base "
+            >
+              로그아웃
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            className="inline-flex items-center bg-gray-100 border-0 py-1 px-3 focus:outline-none hover:bg-gray-200 rounded text-base "
+          >
+            <Link href="/user/login">로그인/회원가입</Link>
+          </button>
+        )}
       </div>
     </header>
   )

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -5,13 +5,15 @@ import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
 import searchIDSlice from './search-id-slice'
 import searchPwSlice from './search-password-slice'
 import searchRecipeSlice from './search-recipe-slice'
+import writeUserRecipeSlice from './write-userRecipe-slice'
 import userInfoSlice from './user-info-slice'
 
 const rootReducer = {
   searchIdData: searchIDSlice.reducer,
   searchPwData: searchPwSlice.reducer,
   searchMain: searchRecipeSlice,
-  userInfo: userInfoSlice.reducer,
+  writeRecipe: writeUserRecipeSlice,
+  userInfo: userInfoSlice,
 }
 
 const store = configureStore({

--- a/src/store/user-info-slice.ts
+++ b/src/store/user-info-slice.ts
@@ -1,6 +1,6 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit'
 
-interface LoginInfo {
+export interface LoginInfo {
   id: string | null
   loginId: string | null
   loginType: string | null
@@ -17,7 +17,7 @@ const initialState: LoginInfo = {
 }
 
 const userInfoSlice = createSlice({
-  name: 'userInfoSlice',
+  name: 'userInfo',
   initialState,
   reducers: {
     getLoginInfo: (state, action: PayloadAction<LoginInfo>) => {
@@ -31,4 +31,4 @@ const userInfoSlice = createSlice({
 })
 
 export const { getLoginInfo } = userInfoSlice.actions
-export default userInfoSlice
+export default userInfoSlice.reducer


### PR DESCRIPTION
로그아웃이 완료됐을 때 로그인 버튼('/user/login' 라우팅)이 렌더링
로그인이 완료 됐을 때 로그아웃 버튼(localstorage의 accessToken 삭제, redux state초기화, '/' 라우팅) 및 유저 닉네임('/my-page'로 라우팅) 렌더링