### PR TITLE
Leor

### DIFF
--- a/src/api/recipe-apis.ts
+++ b/src/api/recipe-apis.ts
@@ -1,4 +1,3 @@
-import { UpdateData } from '@/app/list-page/user-recipes/modification/page'
 import {
   DetailRecipe,
   Options,
@@ -133,6 +132,14 @@ export async function postUserWrite(apiPath: string, data: any, image: any) {
 }
 
 // 게시글 수정
+export interface UpdateData {
+  postContent: string
+  postTitle: string
+  postServing: string
+  postCookingTime: string
+  postCookingLevel: string
+  postPassword: string
+}
 export async function postUserMod(
   apiPath: string,
   data: UpdateData,

--- a/src/app/list-page/user-recipes/[id]/page.tsx
+++ b/src/app/list-page/user-recipes/[id]/page.tsx
@@ -23,9 +23,11 @@ export default function RecipeDetailUser() {
   const thisId = Number(params.id)
   const userInfo = useSelector((state: RootState) => state.userInfo)
   const dispatch = useDispatch()
+
   useEffect(() => {
     getDataLike()
   }, [like])
+
   async function getDataLike() {
     try {
       const result = await getUserPostingDetail(
@@ -63,6 +65,7 @@ export default function RecipeDetailUser() {
       console.log(error)
     }
   }
+
   async function likeHandler() {
     const userId = userInfo.id
     const option = {
@@ -87,9 +90,9 @@ export default function RecipeDetailUser() {
         password: postPw,
         postId: thisInfo?.id,
       }
-      const result = await verifyPw('/api/valid/posts', body)
+      await verifyPw('/api/valid/posts', body)
       if (orDelMod === 'mod') {
-        dispatch(recipeId(thisInfo))
+        dispatch(recipeId(thisInfo?.id))
         window.location.href = '/list-page/user-recipes/modification'
       }
       if (orDelMod === 'del') {

--- a/src/app/my-page/success/viewMyPosting/page.tsx
+++ b/src/app/my-page/success/viewMyPosting/page.tsx
@@ -2,9 +2,11 @@
 import { inquiryPosting } from '@/api/login-user-apis'
 import { postUserDel } from '@/api/recipe-apis'
 import { RootState } from '@/store'
+import { recipeId } from '@/store/mod-userRecipe-slice'
 import { MyPostings } from '@/types/user'
 import Link from 'next/link'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { useDispatch } from 'react-redux'
 import { useSelector } from 'react-redux'
 
 export default function ViewMyPosting() {
@@ -14,6 +16,7 @@ export default function ViewMyPosting() {
   const [mount, setMount] = useState<boolean>(false)
 
   const state = useSelector((state: RootState) => state.userInfo)
+  const dispatch = useDispatch()
   const loader = useRef(null)
 
   useEffect(() => {
@@ -51,6 +54,10 @@ export default function ViewMyPosting() {
     } catch (error) {
       console.log(error)
     }
+  }
+  async function modPosting(thisId: number) {
+    dispatch(recipeId(thisId))
+    window.location.href = '/list-page/user-recipes/modification'
   }
 
   // Intersection Observer 콜백 함수
@@ -94,7 +101,13 @@ export default function ViewMyPosting() {
                     </Link>
                   </li>
                   <li className="py-3">
-                    <button className="mr-5">수정</button>
+                    <button
+                      type="button"
+                      onClick={() => modPosting(item.id)}
+                      className="mr-5"
+                    >
+                      수정
+                    </button>
                     <button
                       type="button"
                       onClick={() => deletePosting(item.id)}

--- a/src/store/mod-userRecipe-slice.ts
+++ b/src/store/mod-userRecipe-slice.ts
@@ -1,33 +1,7 @@
 import { PostingDetailMember, PostingDetailRecipe } from '@/types/recipe'
 import { createSlice } from '@reduxjs/toolkit'
 
-interface InitState {
-  create_at: null | string
-  id: null | number
-  postContent: null | string
-  postCookingLevel: null | string
-  postCookingTime: null | string
-  postImageUrl: null | string
-  postLikeCount: null | number
-  postServing: null | string
-  postTitle: null | string
-  member: null | PostingDetailMember
-  recipe: null | PostingDetailRecipe
-}
-
-const initialState: InitState = {
-  create_at: null,
-  id: null,
-  postContent: null,
-  postCookingLevel: null,
-  postCookingTime: null,
-  postImageUrl: null,
-  postLikeCount: null,
-  postServing: null,
-  postTitle: null,
-  member: null,
-  recipe: null,
-}
+const initialState: null = null
 
 const modRecipeSlice = createSlice({
   name: 'modRecipe',

--- a/src/types/recipe.ts
+++ b/src/types/recipe.ts
@@ -85,3 +85,18 @@ export interface DetailUserRecipe extends Record<string, any> {
   postServing: string
   postTitle: string
 }
+
+// 수정페이지 렌더링용 초기 데이터
+export interface ModData {
+  create_at: string
+  id: number
+  postContent: string
+  postCookingLevel: string
+  postCookingTime: string
+  postImageUrl: string
+  postLikeCount: number
+  postServing: string
+  postTitle: string
+  member: PostingDetailMember
+  recipe: PostingDetailRecipe
+}


### PR DESCRIPTION
마이페이지 - 게시글 수정기능 (라우팅 및 [redux]해당 게시글의 id를 전역으로 저장)

수정페이지
기존: 게시글 상세페이지에서 redux로 데이터를 넘겨주는 방식
변경: 게시글의 id를 사용해서 데이터를 fetch