### PR TITLE
🐛Fix: 회원탈퇴 시 로그아웃이 안되는 현상 수정

### DIFF
--- a/src/app/oauth2/unlink/page.tsx
+++ b/src/app/oauth2/unlink/page.tsx
@@ -5,14 +5,10 @@ import { getLoginInfo } from '@/store/user-info-slice'
 import Link from 'next/link'
 import { useDispatch } from 'react-redux'
 
-export default function UnLink({
-  searchParams,
-}: {
-  searchParams: { [key: string]: string }
-}) {
+export default function UnLink() {
   const dispatch = useDispatch()
 
-  const isUnLink = searchParams.status
+  const isUnLink = new URL(window.location.href).searchParams.get('status')
   if (isUnLink == 'true') {
     const nullState = {
       id: null,


### PR DESCRIPTION
소셜로그인 회원탈퇴 시 redirect시킨 path에서 searchParams를 참조하지 못하는 이슈.
props에서 참조하던 값을 new URL(window.location.href)을 사용해 변수 선언