### PR TITLE
Leor

### DIFF
--- a/src/api/notify-apis.ts
+++ b/src/api/notify-apis.ts
@@ -48,7 +48,7 @@ export async function deleteNotify(notificationIds: number | number[] | null) {
   if (Array.isArray(notificationIds)) {
     const { payload } = await requester({
       method: 'DELETE',
-      url: '/api/user/user/notification',
+      url: '/api/user/notification',
       params: { notificationIds },
       paramsSerializer: (paramObj) => {
         const params = new URLSearchParams()
@@ -64,7 +64,7 @@ export async function deleteNotify(notificationIds: number | number[] | null) {
     // 단일 삭제
     const { payload } = await requester({
       method: 'DELETE',
-      url: '/api/user/user/notification',
+      url: '/api/user/notification',
       params: { notificationIds },
     })
     return payload

--- a/src/api/recipe-apis.ts
+++ b/src/api/recipe-apis.ts
@@ -8,6 +8,9 @@ import {
   GetHomePosting,
   GetHomePostingParams,
   GetHomeRecipe,
+  GetPostingAboutRecipe,
+  GetPostingAboutRecipePageable,
+  GetPostingAboutRecipeParams,
   GetPostingDetail,
   GetPostingList,
   GetPostingListParams,
@@ -58,11 +61,11 @@ export async function getCategoryRecipe(
 }
 
 // 홈(게시글)
-export async function getHomePosting(params: GetHomePostingParams) {
+export async function getHomePosting(/* params: GetHomePostingParams */) {
   const { payload } = await requester<GetHomePosting>({
     method: 'GET',
-    url: '/api/posts',
-    params,
+    url: '/api/posts/main',
+    // params,
   })
   return payload
 }
@@ -200,6 +203,61 @@ export async function commentDel(req: CommentDelReq) {
     method: 'Delete',
     url: '/api/user/comments',
     data: req,
+  })
+  return payload
+}
+
+// 게시글 BEST (레시피 상세페이지)
+interface GetTopPostingParams {
+  recipeId: number
+}
+interface AxiosTopPosting extends Response {
+  data: {
+    id: number
+    post: TopPosting[]
+  }
+}
+export interface TopPosting {
+  id: number
+  postTitle: string
+  createAt: string
+  postLikeCount: number
+  postImageUrl: string
+  member: {
+    nickname: string
+  }
+}
+export async function getTopPosting(params: GetTopPostingParams) {
+  const { payload } = await requester<AxiosTopPosting>({
+    method: 'GET',
+    url: '/api/top/posts',
+    params,
+  })
+  return payload
+}
+
+// 게시글 - 레시피 참조
+export async function getPostingAboutRecipe(
+  recipeId: number,
+  params: GetPostingAboutRecipePageable,
+  last?: GetPostingAboutRecipeParams,
+) {
+  const newQuery = new URLSearchParams()
+  if (last && last.lastLikeCount === 0) {
+    newQuery.append('lastCount', String(last.lastLikeCount))
+    newQuery.append('lastId', String(last.lastId))
+  }
+  if (last && last.lastLikeCount > 0) {
+    newQuery.append('lastCount', String(last.lastLikeCount))
+  }
+
+  const { payload } = await requester<GetPostingAboutRecipe>({
+    method: 'GET',
+    // url: `/api/posts/${recipeId}`,
+    url: last
+      ? `/api/posts/${recipeId}?${newQuery.toString()}`
+      : `/api/posts/${recipeId}`,
+    params,
   })
   return payload
 }

--- a/src/api/recipe-apis.ts
+++ b/src/api/recipe-apis.ts
@@ -61,11 +61,11 @@ export async function getCategoryRecipe(
 }
 
 // 홈(게시글)
-export async function getHomePosting(/* params: GetHomePostingParams */) {
+export async function getHomePosting(params: GetHomePostingParams) {
   const { payload } = await requester<GetHomePosting>({
     method: 'GET',
     url: '/api/posts/main',
-    // params,
+    params,
   })
   return payload
 }

--- a/src/app/list-page/main-recipes/[id]/page.tsx
+++ b/src/app/list-page/main-recipes/[id]/page.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/api/login-user-apis'
 import { useSelector } from 'react-redux'
 import { RootState } from '@/store'
+import PostingTop from './posting-top'
 
 export default function RecipeDetailMain() {
   const [thisInfo, setThisInfo] = useState<RecipeDetail>()
@@ -218,6 +219,7 @@ export default function RecipeDetailMain() {
           </section>
         </article>
       )}
+      <PostingTop id={thisId} />
     </>
   )
 }

--- a/src/app/list-page/main-recipes/[id]/posting-top.tsx
+++ b/src/app/list-page/main-recipes/[id]/posting-top.tsx
@@ -1,0 +1,63 @@
+import { TopPosting, getTopPosting } from '@/api/recipe-apis'
+import Image from 'next/image'
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+
+interface PostingTopProps {
+  id: number
+}
+export default function PostingTop({ id }: PostingTopProps) {
+  const [topPosting, setTopPosting] = useState<TopPosting[]>([])
+  useEffect(() => {
+    getData()
+  }, [])
+
+  async function getData() {
+    try {
+      const option = {
+        recipeId: id,
+      }
+      const result = await getTopPosting(option)
+      setTopPosting(result.data.post)
+    } catch (error) {
+      console.log(error)
+    }
+  }
+
+  const newParams = new URLSearchParams()
+  newParams.append('recipeid', String(id))
+  const newUrl = `/list-page/user-recipes?${newParams.toString()}`
+
+  return (
+    <section className="p-3 mt-3">
+      <div className="flex justify-between items-center pb-3 mb-5 border-b">
+        <h4 className="text-2xl">베스트 후기</h4>
+        <Link href={newUrl}>더보기</Link>
+      </div>
+      <div className=" grid md:gap-10 md:grid-cols-4 gap-5 grid-cols-2">
+        {topPosting.map((item, index) => {
+          return (
+            <Link key={item.id} href={`/list-page/user-recipes/${item.id}`}>
+              <figure className="flex flex-col overflow-hidden rounded shadow-md">
+                <Image
+                  src={item.postImageUrl}
+                  alt={item.postTitle}
+                  width={500}
+                  height={500}
+                  className="md:h-56 w-full"
+                />
+                <figcaption className="p-4">
+                  <p className="mb-1 flex justify-between text-xs font-medium text-gray-600">
+                    <span>{item.member.nickname}</span>
+                    <span>좋아요: {item.postLikeCount}</span>
+                  </p>
+                  <p className="font-medium">{item.postTitle}</p>
+                </figcaption>
+              </figure>
+            </Link>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/src/app/my-page/success/answer/page.tsx
+++ b/src/app/my-page/success/answer/page.tsx
@@ -124,7 +124,7 @@ export default function Answer() {
     <>
       <h4 className="text-center text-lg mb-3">문의내역</h4>
       <div className="h-[60vh] sm:h-[70vh] bg-white overflow-y-scroll mb-3">
-        <div className="rounded-lg p-4">
+        <div className="rounded-lg pb-4">
           <table className="w-full border-gray-200 table-fixed">
             <InputTableHeader
               theadOptions={[

--- a/src/app/my-page/success/view-my-bookmark/page.tsx
+++ b/src/app/my-page/success/view-my-bookmark/page.tsx
@@ -85,7 +85,7 @@ export default function ViewBookmark() {
     <>
       <h4 className="text-center text-lg mb-3">즐겨찾기</h4>
       <div className="h-[70vh] bg-white overflow-y-scroll">
-        <div className="rounded-lg p-4">
+        <div className="rounded-lg pb-4">
           <table className="w-full border-gray-200 table-fixed">
             <TableHeader
               theadOptions={[

--- a/src/app/my-page/success/view-my-posting/page.tsx
+++ b/src/app/my-page/success/view-my-posting/page.tsx
@@ -91,13 +91,13 @@ export default function ViewMyPosting() {
     <>
       <h4 className="text-center text-lg mb-3">내가 작성한 글</h4>
       <div className="h-[70vh] bg-white overflow-y-scroll">
-        <div className="rounded-lg p-4">
+        <div className="rounded-lg pb-4">
           <table className="w-full border-gray-200 table-fixed">
             <TableHeader
               theadOptions={[
                 { class: 'p-2 w-[10%]', title: '#' },
                 { class: 'p-2 sm:w-[70%] w-[60%]', title: '제목' },
-                { class: 'p-2 sm:w-[20%] w-[30%]', title: '삭제' },
+                { class: 'p-2 sm:w-[20%] w-[30%]', title: '기능' },
               ]}
             />
             {posting.length > 0 ? (

--- a/src/app/my-page/success/view-posting-likes/page.tsx
+++ b/src/app/my-page/success/view-posting-likes/page.tsx
@@ -91,7 +91,7 @@ export default function ViewPostingLikes() {
     <>
       <h4 className="text-center text-lg mb-3">좋아요한 게시글</h4>
       <div className="h-[70vh] bg-white overflow-y-scroll">
-        <div className="rounded-lg p-4">
+        <div className="rounded-lg pb-4">
           <table className="w-full border-gray-200 table-fixed">
             <TableHeader
               theadOptions={[

--- a/src/app/my-page/success/view-recipe-likes/page.tsx
+++ b/src/app/my-page/success/view-recipe-likes/page.tsx
@@ -90,7 +90,7 @@ export default function ViewRecipeLikes() {
     <>
       <h4 className="text-center text-lg mb-3">좋아요한 레시피</h4>
       <div className="h-[70vh] bg-white overflow-y-scroll">
-        <div className="rounded-lg p-4">
+        <div className="rounded-lg pb-4">
           <table className="w-full border-gray-200 table-fixed">
             <TableHeader
               theadOptions={[

--- a/src/app/notification/page.tsx
+++ b/src/app/notification/page.tsx
@@ -119,7 +119,7 @@ export default function Notification() {
     <>
       <h4 className="text-center text-lg mb-3">알림</h4>
       <div className="h-[60vh] sm:h-[70vh] bg-white overflow-y-scroll mb-3">
-        <div className="rounded-lg p-4">
+        <div className="rounded-lg">
           <table className="w-full border-gray-200 table-fixed">
             <InputTableHeader
               theadOptions={[

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,4 @@
 'use client'
-import Image from 'next/image'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import {
@@ -64,7 +63,7 @@ export default function Home() {
         setRecipes(result.recipes)
       }
       const result_posting = await getHomePosting(option)
-      setUserPosting(result_posting.data.posts)
+      setUserPosting(result_posting.data.post)
     } catch (error) {
       console.log(error)
     }

--- a/src/components/header-responsive.tsx
+++ b/src/components/header-responsive.tsx
@@ -2,22 +2,35 @@ import Image from 'next/image'
 import Link from 'next/link'
 import NotifyRecent from './user/notify-recent'
 import { LoginInfo } from '@/store/user-info-slice'
-import { useState } from 'react'
+import React, { useState } from 'react'
 
 interface HeaderSizeWebProps {
   isSession: boolean
   eventCount: number
   state: LoginInfo
+  inputValue: string
   logOutBtn: () => void
+  searchHeader: (e: any) => void
+  setInputValue: (value: string) => void
+  toggleProfile: boolean
+  toggleNotify: boolean
+  setToggleProfile: React.Dispatch<React.SetStateAction<boolean>>
+  setToggleNotify: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 export function HeaderSizeWeb({
   isSession,
   eventCount,
   state,
+  inputValue,
   logOutBtn,
+  searchHeader,
+  setInputValue,
+  toggleProfile,
+  toggleNotify,
+  setToggleProfile,
+  setToggleNotify,
 }: HeaderSizeWebProps) {
-  const [profile, setProfile] = useState<boolean>(false)
   return (
     <>
       {/* nav */}
@@ -49,7 +62,7 @@ export function HeaderSizeWeb({
       </div>
       {/* input */}
       <div className="grow md:block hidden">
-        <form className="relative z-50">
+        <form onSubmit={searchHeader} className="relative z-50">
           <button
             type="submit"
             className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"
@@ -58,6 +71,8 @@ export function HeaderSizeWeb({
           </button>
           <input
             type="text"
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
             className="w-11/12 pl-10 pr-3 py-2 border border-transparent rounded-md leading-5 text-gray-300 focus:outline-none focus:bg-white focus:text-gray-900 sm:text-sm transition duration-150 ease-in-out"
             placeholder="Search"
           />
@@ -75,10 +90,14 @@ export function HeaderSizeWeb({
         )}
         {isSession && (
           <div className="flex items-center">
-            <NotifyRecent eventCount={eventCount} />
+            <NotifyRecent
+              eventCount={eventCount}
+              toggleNotify={toggleNotify}
+              setToggleNotify={setToggleNotify}
+            />
             <div className="relative">
               <p
-                onClick={() => setProfile((prev) => !prev)}
+                onClick={() => setToggleProfile((prev) => !prev)}
                 className="border rounded-full py-1 px-2 cursor-pointer "
               >
                 {state.roles === 'ROLE_ADMIN' && <>관</>}
@@ -86,11 +105,11 @@ export function HeaderSizeWeb({
                   <>{state.nickName && state.nickName[0]}</>
                 )}
               </p>
-              {profile && (
+              {toggleProfile && (
                 <div className="absolute w-[150px] right-0 top-[46px] bg-white">
                   <ul
                     className="py-1 px-3"
-                    onClick={() => setProfile((prev) => !prev)}
+                    onClick={() => setToggleProfile((prev) => !prev)}
                   >
                     <li className="py-2 hover:bg-gray-100">
                       {state.roles === 'ROLE_ADMIN' && (
@@ -133,28 +152,58 @@ export function HeaderSizeWeb({
 interface HeaderSizeMobileProps {
   isSession: boolean
   eventCount: number
+  inputValue: string
   logOutBtn: () => void
+  searchHeader: (e: any) => void
+  setInputValue: (value: string) => void
+  toggleMenu: boolean
+  toggleSearch: boolean
+  toggleNotify: boolean
+  setToggleMenu: React.Dispatch<React.SetStateAction<boolean>>
+  setToggleSearch: React.Dispatch<React.SetStateAction<boolean>>
+  setToggleNotify: React.Dispatch<React.SetStateAction<boolean>>
 }
 export function HeaderSizeMobile({
   isSession,
   eventCount,
+  inputValue,
   logOutBtn,
+  searchHeader,
+  setInputValue,
+  toggleMenu,
+  toggleSearch,
+  toggleNotify,
+  setToggleMenu,
+  setToggleSearch,
+  setToggleNotify,
 }: HeaderSizeMobileProps) {
-  const [open, setOpen] = useState<boolean>(false)
-  const [search, setSearch] = useState<boolean>(false)
   return (
     <>
       {/* icons */}
-      <div className="flex md:hidden">
-        <button type="button" onClick={() => setSearch((prev) => !prev)}>
+      <div className="w-[100px] flex justify-between items-center md:hidden">
+        <button type="button" onClick={() => setToggleSearch((prev) => !prev)}>
           <Image src="/svg/search.svg" alt="검색" width={30} height={30} />
         </button>
-        <NotifyRecent eventCount={eventCount} />
+        {isSession && (
+          <NotifyRecent
+            eventCount={eventCount}
+            toggleNotify={toggleNotify}
+            setToggleNotify={setToggleNotify}
+          />
+        )}
+        <div className="" onClick={() => setToggleMenu((prev) => !prev)}>
+          <Image
+            src={toggleMenu ? '/svg/close.svg' : '/svg/hamburger.svg'}
+            alt="메뉴"
+            width={30}
+            height={30}
+          />
+        </div>
       </div>
       {/* spread menu */}
-      {open && (
+      {toggleMenu && (
         <div
-          onClick={() => setOpen((prev) => !prev)}
+          onClick={() => setToggleMenu((prev) => !prev)}
           className="fixed block w-full top-[71px] left-0 bg-white shadow-md md:hidden"
         >
           <ul className="border-b">
@@ -214,10 +263,13 @@ export function HeaderSizeMobile({
           </ul>
         </div>
       )}
-      {/* spread search */}
-      {search && (
+      {/* spread toggleSearch */}
+      {toggleSearch && (
         <div className="w-full py-5 fixed left-0 top-[71px] block md:hidden shadow-md bg-white">
-          <form className="relative z-50 w-11/12 mx-auto">
+          <form
+            onSubmit={searchHeader}
+            className="relative z-50 w-11/12 mx-auto"
+          >
             <button
               type="submit"
               className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"
@@ -226,25 +278,14 @@ export function HeaderSizeMobile({
             </button>
             <input
               type="text"
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
               className="w-full pl-10 pr-3 py-2 border rounded-md leading-5 text-gray-300 focus:outline-none focus:bg-white focus:text-gray-900 sm:text-sm transition duration-150 ease-in-out"
               placeholder="요리명 검색"
             />
           </form>
         </div>
       )}
-
-      {/* hamburger and close btn */}
-      <div
-        className="absolute right-3 top-5 block md:hidden"
-        onClick={() => setOpen((prev) => !prev)}
-      >
-        <Image
-          src={open ? '/svg/close.svg' : '/svg/hamburger.svg'}
-          alt="메뉴"
-          width={30}
-          height={30}
-        />
-      </div>
     </>
   )
 }

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -11,14 +11,17 @@ import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
 import { HeaderSizeMobile, HeaderSizeWeb } from './header-responsive'
+import { useRouter } from 'next/navigation'
 
 export default function Header() {
   const [isSession, setIsSession] = useState<boolean>(false)
+  const [inputValue, setInputValue] = useState<string>('')
 
   const state = useAppSelector((state) => state.userInfo)
   const visitedInfo = useAppSelector((state) => state.visited)
   const dispatch = useAppDispatch()
   const accessToken = getLocalStorage('accessToken')
+  const router = useRouter()
 
   // access token이 있을 때 유저 정보를 확인하는 api요청
   useEffect(() => {
@@ -141,6 +144,42 @@ export default function Header() {
     fetchVisit()
   }, [dispatch, visitedInfo])
 
+  function searchHeader(e: any): void {
+    e.preventDefault()
+    const newParams = new URLSearchParams()
+    newParams.append('title', inputValue)
+    const newUrl = `/list-page/main-recipes?${newParams.toString()}`
+    setInputValue('')
+    router.push(newUrl)
+  }
+
+  // toggle
+  const [toggleProfile, setToggleProfile] = useState<boolean>(false)
+  const [toggleNotify, setToggleNotify] = useState<boolean>(false)
+  const [toggleMenu, setToggleMenu] = useState<boolean>(false)
+  const [toggleSearch, setToggleSearch] = useState<boolean>(false)
+
+  useEffect(() => {
+    if (toggleProfile) {
+      setToggleNotify(false)
+      setToggleMenu(false)
+    }
+    if (toggleNotify) {
+      setToggleProfile(false)
+      setToggleMenu(false)
+      setToggleSearch(false)
+    }
+    if (toggleMenu) {
+      setToggleProfile(false)
+      setToggleNotify(false)
+      setToggleSearch(false)
+    }
+    if (toggleSearch) {
+      setToggleNotify(false)
+      setToggleMenu(false)
+    }
+  }, [toggleProfile, toggleNotify, toggleMenu, toggleSearch])
+
   return (
     <header className="w-full fixed text-gray-600 body-font z-50 bg-gray-300 ">
       <nav className="max-w-[1160px] flex flex-wrap items-center justify-between  px-6 py-4 shadow-sm mx-auto">
@@ -165,12 +204,28 @@ export default function Header() {
           isSession={isSession}
           eventCount={eventCount}
           state={state}
+          inputValue={inputValue}
           logOutBtn={logOutBtn}
+          searchHeader={searchHeader}
+          setInputValue={setInputValue}
+          toggleProfile={toggleProfile}
+          toggleNotify={toggleNotify}
+          setToggleProfile={setToggleProfile}
+          setToggleNotify={setToggleNotify}
         />
         <HeaderSizeMobile
           isSession={isSession}
           eventCount={eventCount}
+          inputValue={inputValue}
           logOutBtn={logOutBtn}
+          searchHeader={searchHeader}
+          setInputValue={setInputValue}
+          toggleMenu={toggleMenu}
+          toggleSearch={toggleSearch}
+          toggleNotify={toggleNotify}
+          setToggleMenu={setToggleMenu}
+          setToggleSearch={setToggleSearch}
+          setToggleNotify={setToggleNotify}
         />
       </nav>
     </header>

--- a/src/components/layout/my-page-sidebar.tsx
+++ b/src/components/layout/my-page-sidebar.tsx
@@ -11,7 +11,7 @@ export default function MypageNav() {
       {!isNav && (
         <p
           onClick={() => setIsNav(true)}
-          className="absolute min-w-[30px] z-20"
+          className="absolute min-w-[30px] z-20 pt-2"
         >
           <Image
             src="/svg/hamburger.svg"
@@ -26,7 +26,7 @@ export default function MypageNav() {
         <>
           <p
             onClick={() => setIsNav(false)}
-            className="absolute min-w-[30px] z-20"
+            className="absolute min-w-[30px] z-30 pt-2"
           >
             <Image
               src="/svg/close.svg"
@@ -36,7 +36,7 @@ export default function MypageNav() {
               className="cursor-pointer"
             />
           </p>
-          <div className="absolute h-full flex bg-gray-200">
+          <div className="absolute h-full flex bg-gray-200 z-20">
             <nav className="flex flex-col items-center bg-white text-gray-700 shadow h-full">
               <div className="h-16 mt-6 flex items-center justify-center w-full text-xl">
                 마이페이지

--- a/src/components/recipe-and-posting/recipe-figure.tsx
+++ b/src/components/recipe-and-posting/recipe-figure.tsx
@@ -54,49 +54,13 @@ interface PostingFigureProps {
 export function UserPostingFigure({ recipes }: PostingFigureProps) {
   return (
     <>
-      {/* {recipes?.map((item) => {
-        return (
-          <figure
-            key={item.id}
-            className="rounded-lg border border-[#C6C6C6] shadow-md max-w-xs md:max-w-none overflow-hidden py-3"
-          >
-            <Image
-              src={item.postImageUrl}
-              alt={item.postTitle}
-              width={500}
-              height={500}
-              className="h-56 lg:h-60 w-11/12 mx-auto rounded border border-[#C6C6C6]"
-              priority
-            />
-            <figcaption className="w-11/12 mx-auto pt-3 text-gray-300">
-              <span className="block text-sm text-primary text-right text-[#77D8B6]">
-                {item.createdAt}
-              </span>
-              <dl>
-                <dt className="font-semibold text-xl leading-6 my-2 text-black">
-                  {item.postTitle}
-                </dt>
-                <dd className="paragraph-normal text-[#9B9B9B]">
-                  {item.member.nickname}님 작성
-                </dd>
-              </dl>
-              <Link
-                className="mt-3 block text-[#1D1D1D]"
-                href={`/list-page/user-recipes/${item.id}`}
-              >
-                자세히 보기
-              </Link>
-            </figcaption>
-          </figure>
-        )
-      })} */}
       {recipes?.map((item) => {
         return (
           <figure
             key={item.id}
             className="flex flex-col items-center rounded-lg border border-gray-200 shadow-md overflow-hidden"
           >
-            <div className="relative w-full pt-[100%]">
+            <div className="relative md:w-full pt-[100%]">
               <Image
                 src={item.postImageUrl}
                 alt={item.postTitle}
@@ -106,23 +70,18 @@ export function UserPostingFigure({ recipes }: PostingFigureProps) {
                 priority
               />
             </div>
-            <figcaption className="w-full text-left">
-              <div className="flex justify-between items-center mb-2">
-                <span className="block text-sm text-gray-500">
-                  {item.createdAt}
-                </span>
-                <span className="block text-sm text-gray-500">
+            <figcaption className="p-4 w-full">
+              <div className="flex flex-col md:flex-row md:justify-between md:items-center mb-2">
+                <span className="text-sm text-green-600 font-semibold">
                   {item.member.nickname}
                 </span>
+                <span className="text-sm text-gray-500">{item.createdAt}</span>
               </div>
               <h3 className="font-semibold text-lg text-black mb-2">
                 {item.postTitle}
               </h3>
-              <Link
-                className="block text-blue-500 font-semibold"
-                href={`/list-page/user-recipes/${item.id}`}
-              >
-                자세히 보기
+              <Link href={`/list-page/user-recipes/${item.id}`}>
+                <p className="text-blue-500 font-semibold">자세히 보기</p>
               </Link>
             </figcaption>
           </figure>

--- a/src/components/user/infinite-paging/input/input-table-body-common.tsx
+++ b/src/components/user/infinite-paging/input/input-table-body-common.tsx
@@ -18,27 +18,27 @@ export default function InputTableBodyCommon({
 }: InputTableBodyCommonProps) {
   return (
     <>
-      <td className="px-2 py-5 text-center ">
+      <td className="px-2 py-3 text-center ">
         <input
           type="checkbox"
           onChange={() => onChange(convertData.id)}
           className="chk_box"
         />
       </td>
-      <td className="px-2 py-5 text-center whitespace-nowrap text-ellipsis overflow-hidden">
+      <td className="px-2 text-center whitespace-nowrap text-ellipsis overflow-hidden">
         <Link href={convertData.url}>{convertData.title}</Link>
       </td>
       {isStatus && (
-        <td className="px-2 py-5 flex justify-center">
+        <td className="px-2 flex justify-center itmes-center">
           <Image
             src={`/svg/${convertData.status === 'COMPLETED' ? 'completed' : 'pending'}.svg`}
             alt={convertData.status === 'COMPLETED' ? '완료' : '대기중'}
-            width={30}
-            height={30}
+            width={46}
+            height={46}
           />
         </td>
       )}
-      <td className="px-2 py-5 text-center">
+      <td className="px-2 text-center">
         <InputTableButton id={convertData.id} onClick={onClick} />
       </td>
     </>

--- a/src/components/user/infinite-paging/input/input-table-body.tsx
+++ b/src/components/user/infinite-paging/input/input-table-body.tsx
@@ -53,7 +53,7 @@ export default function InputTableBody({
         const convertData = converHandler(item)
         return (
           convertData && (
-            <tr key={convertData.id}>
+            <tr key={convertData.id} className="border-b">
               <InputTableBodyCommon
                 convertData={convertData}
                 isStatus={isStatus}

--- a/src/components/user/infinite-paging/input/input-table-header.tsx
+++ b/src/components/user/infinite-paging/input/input-table-header.tsx
@@ -11,7 +11,7 @@ export default function InputTableHeader({
 }: InputTableHeaderProps) {
   return (
     <thead>
-      <tr>
+      <tr className="bg-gray-100 sticky top-0">
         <th className="p-2 w-[10%]">
           <input
             type="checkbox"

--- a/src/components/user/infinite-paging/sequence/table-body-common.tsx
+++ b/src/components/user/infinite-paging/sequence/table-body-common.tsx
@@ -10,8 +10,8 @@ export default function TableBodyCommon({
 }) {
   return (
     <>
-      <td className="px-2 py-5 text-center ">{index + 1}</td>
-      <td className="px-2 py-5 text-center whitespace-nowrap text-ellipsis overflow-hidden">
+      <td className="px-2 py-3 text-center ">{index + 1}</td>
+      <td className="px-2 text-center whitespace-nowrap text-ellipsis overflow-hidden">
         <Link href={convertData.url}>{convertData.title}</Link>
       </td>
     </>

--- a/src/components/user/infinite-paging/sequence/table-body.tsx
+++ b/src/components/user/infinite-paging/sequence/table-body.tsx
@@ -80,7 +80,7 @@ export default function TableBody({
                 convertData && (
                   <tr key={convertData.idForKey} className="border-b">
                     <TableBodyCommon index={index} convertData={convertData} />
-                    <td className="px-2 py-5 text-center">
+                    <td className="px-2 text-center">
                       <TableButton
                         label="취소"
                         onClick={onClick}

--- a/src/components/user/notify-recent.tsx
+++ b/src/components/user/notify-recent.tsx
@@ -1,14 +1,21 @@
-'use client'
-
 import { inquiryNotifyRecent } from '@/api/notify-apis'
 import { Notification } from '@/types/notify'
 import Image from 'next/image'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 
-export default function NotifyRecent({ eventCount }: { eventCount: number }) {
+interface NotifyRecentProps {
+  eventCount: number
+  toggleNotify: boolean
+  setToggleNotify: React.Dispatch<React.SetStateAction<boolean>>
+}
+
+export default function NotifyRecent({
+  eventCount,
+  toggleNotify,
+  setToggleNotify,
+}: NotifyRecentProps) {
   const [notify, setNotify] = useState<Notification[]>([])
-  const [isClick, setIsClick] = useState<boolean>(false)
   const [isNew, setIsNew] = useState<boolean>(false)
 
   useEffect(() => {
@@ -18,11 +25,11 @@ export default function NotifyRecent({ eventCount }: { eventCount: number }) {
   }, [eventCount])
 
   useEffect(() => {
-    if (isClick) {
+    if (toggleNotify) {
       getInquiryNotificationRecent()
       setIsNew(false)
     }
-  }, [isClick])
+  }, [toggleNotify])
 
   async function getInquiryNotificationRecent() {
     try {
@@ -35,29 +42,32 @@ export default function NotifyRecent({ eventCount }: { eventCount: number }) {
 
   const bodyWithoutHeader = document.querySelector('body>div')
   bodyWithoutHeader?.addEventListener('click', () => {
-    if (isClick) {
-      setIsClick(false)
+    if (toggleNotify) {
+      setToggleNotify(false)
     }
   })
   return (
-    <div>
+    <div className="md:mr-2 relative">
       <button
         type="button"
-        onClick={() => setIsClick(!isClick)}
-        className="relative flex itmes-center mr-3"
+        onClick={() => setToggleNotify((prev) => !prev)}
+        className="relative flex itmes-center"
       >
         <Image src="/svg/bell.svg" alt="알림버튼" width={30} height={30} />
         {isNew && (
-          <span className="absolute w-[10px] h-[10px] right-1 top-1 bg-red-50 rounded-full"></span>
+          <span className="flex absolute top-0 right-1">
+            <span className="animate-ping absolute inline-flex h-3 w-3 rounded-full bg-pink-400 opacity-75"></span>
+            <span className="relative inline-flex rounded-full h-3 w-3 bg-pink-500"></span>
+          </span>
         )}
       </button>
-      {isClick && (
-        <div className="sm:absolute sm:w-auto sm:left-auto w-full fixed top-[71px] left-0 py-3 px-4 shadow-md bg-white">
+      {toggleNotify && (
+        <div className="md:absolute md:w-[300px] md:top-[46px] md:left-auto md:right-0 w-full fixed top-[71px] left-0 py-3 px-4 shadow-md bg-white">
           <h5 className="border-b- pb-2">알림</h5>
           {notify.map((item) => {
             return (
               <p key={item.id} className="py-2 mb-1 border-b">
-                <Link href={item.url} onClick={() => setIsClick(false)}>
+                <Link href={item.url} onClick={() => setToggleNotify(false)}>
                   {item.content}
                 </Link>
               </p>
@@ -66,7 +76,7 @@ export default function NotifyRecent({ eventCount }: { eventCount: number }) {
           <div>
             <Link
               href="/notification"
-              onClick={() => setIsClick((prev) => !prev)}
+              onClick={() => setToggleNotify((prev) => !prev)}
               className="block text-center"
             >
               전체 보기

--- a/src/types/recipe-apis-type/index.ts
+++ b/src/types/recipe-apis-type/index.ts
@@ -4,6 +4,7 @@ import {
   PostingDetail,
   PostingFigure,
   Recipe,
+  PostingFigureAboutRecipe,
 } from '../recipe'
 
 export interface Response {
@@ -77,6 +78,14 @@ export interface GetCommentParams {
   size: number
   sort: string
 }
+// 게시글 - 레시피 참조(무한스크롤)
+export interface GetPostingAboutRecipePageable {
+  size: number
+}
+export interface GetPostingAboutRecipeParams {
+  lastId: number | null
+  lastLikeCount: number
+}
 
 // ########## axios requester payload options ##########
 // 홈(레시피)
@@ -88,8 +97,8 @@ export interface GetHomeRecipe extends Response {
 // 홈(게시글)
 export interface GetHomePosting extends Response {
   data: {
-    posts: PostingFigure[] | []
-    nextPage: boolean
+    post: PostingFigure[] | []
+    // nextPage: boolean
   }
 }
 // 레시피 - 페이지네이션
@@ -146,5 +155,13 @@ export interface GetComment extends Response {
     }
     totalElements: number
     totalPages: number
+  }
+}
+
+// 게시글 - 레시피 참조
+export interface GetPostingAboutRecipe extends Response {
+  data: {
+    posts: PostingFigureAboutRecipe[]
+    nextPage: boolean
   }
 }

--- a/src/types/recipe.ts
+++ b/src/types/recipe.ts
@@ -2,14 +2,11 @@
 export interface PostingFigure {
   createdAt: string
   id: number
-  member: PostingMember
+  member: {
+    nickname: string
+  }
   postImageUrl: string
   postTitle: string
-  recipe: PostingDetailRecipe
-}
-interface PostingMember {
-  nickname: string
-  loginId: string
 }
 
 // 레시피 검색 req (+[redux] search-recipe-slice)
@@ -93,4 +90,14 @@ export interface ModData {
   postTitle: string
   member: PostingDetailMember
   recipe: PostingDetailRecipe
+}
+
+// 게시글 - 레시피 참조
+export interface PostingFigureAboutRecipe {
+  createdAt: string
+  id: number
+  member: { nickname: string }
+  postImageUrl: string
+  postLikeCount: number
+  postTitle: string
 }


### PR DESCRIPTION
[BEST 게시글]
레시피 상세페이지에서 해당 레시피의 게시글 BEST를 표시
더보기 클릭 시 query string으로 레시피id를 전달 및 게시글 리스트 페이지로 이동
게시글 리스트 페이지에서 전달받은 query로 API 요청

[무한 스크롤 table]
디자인 수정

[Header]
컴포넌트 간 데이터 전달 방식 변경

[figure]
게시글 figure 디자인 변경

[메인페이지]
데이터 참조를 API response body에 맞춤

[마이페이지]
네비게이션 디자인값 수정

[알림]
back-end의 엔드포인트 수정에 따른 front-end에서 동일하게 수정