### PR TITLE
♻️Refactor: 게시글 작성 비밀번호 input type 변경

### DIFF
--- a/src/app/list-page/user-recipes/posting-password.tsx
+++ b/src/app/list-page/user-recipes/posting-password.tsx
@@ -13,7 +13,7 @@ export default function PostingPassword({
     <>
       <label className="mr-2">{label}</label>
       <input
-        type="password"
+        type="text"
         value={value}
         placeholder="비밀번호"
         onChange={(e) => onChange(e.target.value)}


### PR DESCRIPTION
게시글 작성 및 수정 페이지 
input의 type이 password라서 브라우저의 비밀번호 저장 기능이 동작하는 것을 막음