### PR TITLE
Leor

### DIFF
--- a/src/app/list-page/main-recipes/[id]/posting-top.tsx
+++ b/src/app/list-page/main-recipes/[id]/posting-top.tsx
@@ -34,30 +34,34 @@ export default function PostingTop({ id }: PostingTopProps) {
         <h4 className="text-2xl">베스트 후기</h4>
         <Link href={newUrl}>더보기</Link>
       </div>
-      <div className=" grid md:gap-10 md:grid-cols-4 gap-5 grid-cols-2">
-        {topPosting.map((item, index) => {
-          return (
-            <Link key={item.id} href={`/list-page/user-recipes/${item.id}`}>
-              <figure className="flex flex-col overflow-hidden rounded shadow-md">
-                <Image
-                  src={item.postImageUrl}
-                  alt={item.postTitle}
-                  width={500}
-                  height={500}
-                  className="md:h-56 w-full"
-                />
-                <figcaption className="p-4">
-                  <p className="mb-1 flex justify-between text-xs font-medium text-gray-600">
-                    <span>{item.member.nickname}</span>
-                    <span>좋아요: {item.postLikeCount}</span>
-                  </p>
-                  <p className="font-medium">{item.postTitle}</p>
-                </figcaption>
-              </figure>
-            </Link>
-          )
-        })}
-      </div>
+      {topPosting.length > 0 ? (
+        <div className=" grid md:gap-10 md:grid-cols-4 gap-5 grid-cols-2">
+          {topPosting.map((item, index) => {
+            return (
+              <Link key={item.id} href={`/list-page/user-recipes/${item.id}`}>
+                <figure className="flex flex-col overflow-hidden rounded shadow-md">
+                  <Image
+                    src={item.postImageUrl}
+                    alt={item.postTitle}
+                    width={500}
+                    height={500}
+                    className="md:h-56 w-full"
+                  />
+                  <figcaption className="p-4">
+                    <p className="mb-1 flex justify-between text-xs font-medium text-gray-600">
+                      <span>{item.member.nickname}</span>
+                      <span>좋아요: {item.postLikeCount}</span>
+                    </p>
+                    <p className="font-medium">{item.postTitle}</p>
+                  </figcaption>
+                </figure>
+              </Link>
+            )
+          })}
+        </div>
+      ) : (
+        <div>후기가 없습니다</div>
+      )}
     </section>
   )
 }

--- a/src/app/list-page/user-recipes/[id]/page.tsx
+++ b/src/app/list-page/user-recipes/[id]/page.tsx
@@ -12,6 +12,7 @@ import { recipeId } from '@/store/mod-userRecipe-slice'
 import { PostingDetail, ThreeCookInfo } from '@/types/recipe'
 import axios from 'axios'
 import Image from 'next/image'
+import Link from 'next/link'
 import { useParams } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
@@ -187,7 +188,9 @@ export default function RecipeDetailUser() {
           <section className="mb-5 px-5">
             <div className="p-2 min-h-60">
               <p className="text-2xl mb-3 pb-3 border-b border-gray-400">
-                &#91;{thisInfo.recipe.title}&#93;
+                <Link href={`/list-page/main-recipes/${thisInfo.recipe.id}`}>
+                  &#91;{thisInfo.recipe.title}&#93;
+                </Link>
                 <span className="text-lg"> 후기</span>
               </p>
               <p className="overflow-wrap break-words">

--- a/src/app/list-page/user-recipes/page.tsx
+++ b/src/app/list-page/user-recipes/page.tsx
@@ -16,6 +16,7 @@ import Link from 'next/link'
 import { useDispatch } from 'react-redux'
 import { initWriteState } from '@/store/write-userRecipe-slice'
 import { useRouter, useSearchParams } from 'next/navigation'
+import NoResult from '@/components/layout/no-result'
 
 export default function UserRecipes() {
   const [posting, setPosting] = useState<
@@ -175,9 +176,6 @@ export default function UserRecipes() {
     router.push(newUrl)
   }
 
-  if (posting.length < 1) {
-    return <div>loading</div>
-  }
   return (
     <div className="pt-4">
       <form onSubmit={submitHandler}>
@@ -197,10 +195,19 @@ export default function UserRecipes() {
         </div>
       </form>
 
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 md:gap-6 p-2 md:px-8 md:pb-8">
-        <UserPostingFigure recipes={posting} />
-        <div ref={loader} />
-      </div>
+      {query === 'title' && (
+        <h2 className="font-semibold text-lg md:text-xl px-2 md:px-8 mb-2">{`"${queryValue}"에 대한 결과`}</h2>
+      )}
+
+      {posting.length > 0 ? (
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 md:gap-6 p-2 md:px-8 md:pb-8">
+          <UserPostingFigure recipes={posting} />
+          <div ref={loader} />
+        </div>
+      ) : (
+        <NoResult />
+      )}
+
       <aside className="fixed md:w-14 md:h-14 w-10 h-10 md:right-10 bottom-10 right-5 bg-yellow-500 rounded-full">
         <Link
           href="/list-page/user-recipes/write"

--- a/src/app/my-page/page.tsx
+++ b/src/app/my-page/page.tsx
@@ -81,17 +81,17 @@ export default function MyPage() {
               <div>
                 <button
                   type="button"
-                  onClick={() => (window.location.href = '/')}
-                  className="bg-red-500 px-4 py-2 rounded-md text-md text-white"
+                  onClick={() => route.back()}
+                  className="bg-gray-100 px-4 py-2 rounded-md text-md"
                 >
-                  Cancel
+                  돌아가기
                 </button>
                 <button
                   type="submit"
                   onClick={(e) => getAccessRights(e)}
-                  className="bg-indigo-500 px-7 py-2 ml-2 rounded-md text-md text-white font-semibold"
+                  className=" px-7 py-2 ml-2 rounded-md bg-blue-50 text-white text-md font-semibold"
                 >
-                  Ok
+                  확인
                 </button>
               </div>
             </form>

--- a/src/app/my-page/success/answer/page.tsx
+++ b/src/app/my-page/success/answer/page.tsx
@@ -121,8 +121,10 @@ export default function Answer() {
   }, [handleObserver])
 
   return (
-    <>
-      <h4 className="text-center text-lg mb-3">문의내역</h4>
+    <div className="w-10/12 mx-auto p-4">
+      <div className="flex items-center border-b pb-4 mb-4">
+        <h3 className="text-2xl font-semibold">문의내역</h3>
+      </div>
       <div className="h-[60vh] sm:h-[70vh] bg-white overflow-y-scroll mb-3">
         <div className="rounded-lg pb-4">
           <table className="w-full border-gray-200 table-fixed">
@@ -153,6 +155,6 @@ export default function Answer() {
       <div className="text-end">
         <InputDeleteButton onClick={deleteQuestionHandler} />
       </div>
-    </>
+    </div>
   )
 }

--- a/src/app/my-page/success/layout.tsx
+++ b/src/app/my-page/success/layout.tsx
@@ -8,7 +8,7 @@ export default function MyPageLayout({
   return (
     <div className="relative h-full z-20">
       <MyPageNav />
-      <div className="w-10/12 mx-auto pt-11 h-full">{children}</div>
+      <div className="w-full mx-auto pt-11 h-full">{children}</div>
     </div>
   )
 }

--- a/src/app/my-page/success/user-info/page.tsx
+++ b/src/app/my-page/success/user-info/page.tsx
@@ -139,9 +139,9 @@ export default function UserInfo() {
   }
   return (
     <>
-      <div>
+      <div className="w-10/12 mx-auto p-4">
         <div className="mb-36">
-          <h4 className="text-2xl mb-3">기본 정보</h4>
+          <h3 className="text-2xl mb-3">기본 정보</h3>
           <table className="w-full text-sm md:text-base">
             <tbody>
               <tr className="border-b-2">
@@ -169,7 +169,7 @@ export default function UserInfo() {
           </table>
         </div>
         <div>
-          <h4 className="text-2xl mb-3">로그인 정보</h4>
+          <h3 className="text-2xl mb-3">로그인 정보</h3>
           <table className="w-full text-sm md:text-base">
             <tbody>
               <tr className="border-b-2">

--- a/src/app/my-page/success/view-my-bookmark/page.tsx
+++ b/src/app/my-page/success/view-my-bookmark/page.tsx
@@ -82,8 +82,10 @@ export default function ViewBookmark() {
   }, [handleObserver])
 
   return (
-    <>
-      <h4 className="text-center text-lg mb-3">즐겨찾기</h4>
+    <div className="w-10/12 mx-auto p-4">
+      <div className="flex items-center border-b pb-4 mb-4">
+        <h3 className="text-2xl font-semibold">즐겨찾기</h3>
+      </div>
       <div className="h-[70vh] bg-white overflow-y-scroll">
         <div className="rounded-lg pb-4">
           <table className="w-full border-gray-200 table-fixed">
@@ -108,6 +110,6 @@ export default function ViewBookmark() {
           </table>
         </div>
       </div>
-    </>
+    </div>
   )
 }

--- a/src/app/my-page/success/view-my-posting/page.tsx
+++ b/src/app/my-page/success/view-my-posting/page.tsx
@@ -88,10 +88,12 @@ export default function ViewMyPosting() {
   }, [handleObserver])
 
   return (
-    <>
-      <h4 className="text-center text-lg mb-3">내가 작성한 글</h4>
+    <div className="w-10/12 mx-auto p-4">
+      <div className="flex items-center border-b pb-4 mb-4">
+        <h3 className="text-2xl font-semibold">내가 작성한 글</h3>
+      </div>
       <div className="h-[70vh] bg-white overflow-y-scroll">
-        <div className="rounded-lg pb-4">
+        <div className="pb-4">
           <table className="w-full border-gray-200 table-fixed">
             <TableHeader
               theadOptions={[
@@ -115,6 +117,6 @@ export default function ViewMyPosting() {
           </table>
         </div>
       </div>
-    </>
+    </div>
   )
 }

--- a/src/app/my-page/success/view-posting-likes/page.tsx
+++ b/src/app/my-page/success/view-posting-likes/page.tsx
@@ -88,8 +88,10 @@ export default function ViewPostingLikes() {
   }, [handleObserver])
 
   return (
-    <>
-      <h4 className="text-center text-lg mb-3">좋아요한 게시글</h4>
+    <div className="w-10/12 mx-auto p-4">
+      <div className="flex items-center border-b pb-4 mb-4">
+        <h3 className="text-2xl font-semibold">좋아요한 게시글</h3>
+      </div>
       <div className="h-[70vh] bg-white overflow-y-scroll">
         <div className="rounded-lg pb-4">
           <table className="w-full border-gray-200 table-fixed">
@@ -114,6 +116,6 @@ export default function ViewPostingLikes() {
           </table>
         </div>
       </div>
-    </>
+    </div>
   )
 }

--- a/src/app/my-page/success/view-recipe-likes/page.tsx
+++ b/src/app/my-page/success/view-recipe-likes/page.tsx
@@ -87,8 +87,10 @@ export default function ViewRecipeLikes() {
   }, [handleObserver])
 
   return (
-    <>
-      <h4 className="text-center text-lg mb-3">좋아요한 레시피</h4>
+    <div className="w-10/12 mx-auto p-4">
+      <div className="flex items-center border-b pb-4 mb-4">
+        <h3 className="text-2xl font-semibold">좋아요한 레시피</h3>
+      </div>
       <div className="h-[70vh] bg-white overflow-y-scroll">
         <div className="rounded-lg pb-4">
           <table className="w-full border-gray-200 table-fixed">
@@ -113,6 +115,6 @@ export default function ViewRecipeLikes() {
           </table>
         </div>
       </div>
-    </>
+    </div>
   )
 }

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -191,8 +191,8 @@ export default function Header() {
   return (
     <>
       {!isPopup && (
-        <header className="w-full fixed text-gray-600 body-font z-50 bg-white">
-          <nav className="max-w-[1160px] flex flex-wrap items-center justify-between  pl-2 pr-6 py-4 shadow-sm mx-auto">
+        <header className="w-full fixed text-gray-600 body-font z-50 bg-white border-b">
+          <nav className="max-w-[1160px] flex flex-wrap items-center justify-between  pl-2 pr-6 py-4 mx-auto">
             <div className="md:grow-0">
               <h1 className="font-BMJUA text-lg">
                 <Link

--- a/src/components/recipe-and-posting/comment.tsx
+++ b/src/components/recipe-and-posting/comment.tsx
@@ -204,7 +204,7 @@ export function Comment({ thisId, userId }: PropsType) {
                       className="w-full px-2 border rounded-md"
                     ></textarea>
                   ) : (
-                    <p className="text-sm">{item.commentContent}</p>
+                    <p className="text-sm break-words">{item.commentContent}</p>
                   )}
 
                   <div className="mt-5 flex items-center justify-end text-gray-600">


### PR DESCRIPTION
[마이페이지]
디자인 수정
진입 시 초기 화면에서 '취소'버튼을 클릭 시, 홈으로의 이동을 뒤로가기로 변경

[레시피 상세페이지]
베스트 게시글이 존재하지 않을 경우의 렌더링 추가

[게시글 상세페이지]
상세페이지 내부의 레시피명을 클릭 시, 해당 레시피 상세페이지로 이동

[댓글]
댓글의 데이터(문자열)가 길면 레이아웃을 벗어나는 현상을 수정

[Header]
헤더의 shadow 속성을 제거하고 border-bottom으로 대체

[게시글 리스트]
검색결과가 없을 때 알려주는 컴포넌트를 렌더링